### PR TITLE
Add Distribution Modules and Transformed Parameters

### DIFF
--- a/src/rs_distributions/distributions/folded_normal.py
+++ b/src/rs_distributions/distributions/folded_normal.py
@@ -50,6 +50,8 @@ class FoldedNormal(dist.Distribution):
         Returns:
             Tensor: The log-probabilities of the given values
         """
+        if self._validate_args:
+            self._validate_sample(value)
         loc = self.loc
         scale = self.scale
         log_prob = torch.logaddexp(
@@ -109,6 +111,8 @@ class FoldedNormal(dist.Distribution):
         Returns:
             Tensor: The CDF values at the given values
         """
+        if self._validate_args:
+            self._validate_sample(value)
         value = torch.as_tensor(value, dtype=self.loc.dtype, device=self.loc.device)
         # return dist.Normal(loc, scale).cdf(value) - dist.Normal(-loc, scale).cdf(-value)
         return 0.5 * (

--- a/src/rs_distributions/distributions/folded_normal.py
+++ b/src/rs_distributions/distributions/folded_normal.py
@@ -32,6 +32,7 @@ class FoldedNormal(dist.Distribution):
     """
 
     arg_constraints = {"loc": dist.constraints.real, "scale": dist.constraints.positive}
+    support = torch.distributions.constraints.nonnegative
 
     def __init__(self, loc, scale, validate_args=None):
         self.loc = torch.as_tensor(loc)

--- a/src/rs_distributions/modules/__init__.py
+++ b/src/rs_distributions/modules/__init__.py
@@ -1,0 +1,9 @@
+from .transformed_parameter import TransformedParameter  # noqa
+from .distribution import *  # noqa
+from .distribution import __all__
+
+__all__.extend(
+    [
+        "TransformedParameter",
+    ]
+)

--- a/src/rs_distributions/modules/__init__.py
+++ b/src/rs_distributions/modules/__init__.py
@@ -1,9 +1,12 @@
 from .transformed_parameter import TransformedParameter  # noqa
+from .distribution import DistributionModule
 from .distribution import *  # noqa
-from .distribution import __all__
+from .kl import kl_divergence  # noqa
+from .distribution import __all__ as all_distributions
 
-__all__.extend(
-    [
-        "TransformedParameter",
-    ]
-)
+__all__ = [
+    "TransformedParameter",
+    "DistributionModule",
+    "kl_divergence",
+]
+__all__.extend(all_distributions)

--- a/src/rs_distributions/modules/distribution.py
+++ b/src/rs_distributions/modules/distribution.py
@@ -71,11 +71,11 @@ def extract_distributions(module):
     """
     d = {}
     for k in module.__all__:
-        cls = getattr(module, k)
-        if not isclass(cls):
+        distribution_class = getattr(module, k)
+        if not isclass(distribution_class):
             continue
-        if issubclass(cls, torch.distributions.Distribution):
-            d[k] = cls
+        if issubclass(distribution_class, torch.distributions.Distribution):
+            d[k] = distribution_class
     return d
 
 

--- a/src/rs_distributions/modules/distribution.py
+++ b/src/rs_distributions/modules/distribution.py
@@ -1,0 +1,83 @@
+import torch
+from rs_distributions.modules import TransformedParameter
+from rs_distributions import distributions as rsd
+from inspect import signature, isclass
+from functools import wraps
+
+
+def distribution_module_factory(distribution_class):
+    class DistributionModule(torch.nn.Module):
+        __doc__ = distribution_class.__doc__
+
+        @wraps(distribution_class.__init__)
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            sig = signature(distribution_class)
+            bargs = sig.bind(*args, **kwargs)
+            bargs.apply_defaults()
+            for arg in distribution_class.arg_constraints:
+                param = bargs.arguments.pop(arg)
+                param = self._constrain_arg_if_needed(arg, param)
+                setattr(self, f"_{arg}", param)
+            self._extra_args = bargs.arguments
+
+        def __repr__(self):
+            rstring = super().__repr__().split("\n")[1:]
+            rstring = [str(distribution_class) + " DistributionModule("] + rstring
+            return "\n".join(rstring)
+
+        def _distribution(self):
+            kwargs = {
+                k: self._realize_parameter(getattr(self, f"_{k}"))
+                for k in distribution_class.arg_constraints
+            }
+            kwargs.update(self._extra_args)
+            return distribution_class(**kwargs)
+
+        @staticmethod
+        def _constrain_arg_if_needed(name, value):
+            if isinstance(value, TransformedParameter):
+                return value
+            cons = distribution_class.arg_constraints[name]
+            transform = torch.distributions.constraint_registry.transform_to(cons)
+            return TransformedParameter(value, transform)
+
+        @staticmethod
+        def _realize_parameter(param):
+            if isinstance(param, TransformedParameter):
+                return param()
+            return param
+
+        def __getattr__(self, name: str):
+            if name in distribution_class.arg_constraints or hasattr(
+                distribution_class, name
+            ):
+                q = self._distribution()
+                return getattr(q, name)
+            return super().__getattr__(name)
+
+    return DistributionModule
+
+
+distributions_to_transform = {}
+
+
+def extract_distributions(module):
+    """extract distributions from a module into a dict {name: cls}"""
+    d = {}
+    for k in module.__all__:
+        cls = getattr(module, k)
+        if not isclass(cls):
+            continue
+        if issubclass(cls, torch.distributions.Distribution):
+            d[k] = cls
+    return d
+
+
+distributions_to_transform = extract_distributions(torch.distributions)
+distributions_to_transform.update(extract_distributions(rsd))
+
+__all__ = []
+for k, v in distributions_to_transform.items():
+    globals()[k] = distribution_module_factory(v)
+    __all__.append(k)

--- a/src/rs_distributions/modules/distribution.py
+++ b/src/rs_distributions/modules/distribution.py
@@ -4,8 +4,8 @@ from rs_distributions import distributions as rsd
 from inspect import signature, isclass
 from functools import wraps
 
-class DistributionModuleBase(torch.nn.Module):
-    """ Base class for DistributionModules """
+class DistributionModule(torch.nn.Module):
+    """ Base class for learnable distribution classes """
     def __init__(self, distribution_class, *args, **kwargs):
         super().__init__()
         self.distribution_class = distribution_class
@@ -55,7 +55,7 @@ class DistributionModuleBase(torch.nn.Module):
 
     @classmethod
     def generate_subclass(cls, distribution_class):
-        class DistributionModule(DistributionModuleBase):
+        class DistributionModule(DistributionModule):
             __doc__ = distribution_class.__doc__
 
             @wraps(distribution_class.__init__)
@@ -64,7 +64,6 @@ class DistributionModuleBase(torch.nn.Module):
         return DistributionModule
 
 
-distributions_to_transform = {}
 def extract_distributions(module):
     """
     extract all torch.distributions.Distribution subclasses from a module 
@@ -85,6 +84,6 @@ distributions_to_transform.update(extract_distributions(rsd))
 
 __all__ = []
 for k, v in distributions_to_transform.items():
-    globals()[k] = DistributionModuleBase.generate_subclass(v)
+    globals()[k] = DistributionModule.generate_subclass(v)
     __all__.append(k)
 

--- a/src/rs_distributions/modules/kl.py
+++ b/src/rs_distributions/modules/kl.py
@@ -1,0 +1,13 @@
+from functools import wraps
+from rs_distributions import modules as rsm
+import torch
+
+
+@wraps(torch.distributions.kl.kl_divergence)
+def kl_divergence(p, q):
+    if isinstance(p, rsm.DistributionModule):
+        p = p._distribution()
+    if isinstance(q, rsm.DistributionModule):
+        q = q._distribution()
+    return torch.distributions.kl.kl_divergence(p, q)
+

--- a/src/rs_distributions/modules/kl.py
+++ b/src/rs_distributions/modules/kl.py
@@ -10,4 +10,3 @@ def kl_divergence(p, q):
     if isinstance(q, rsm.DistributionModule):
         q = q._distribution()
     return torch.distributions.kl.kl_divergence(p, q)
-

--- a/src/rs_distributions/modules/transformed_parameter.py
+++ b/src/rs_distributions/modules/transformed_parameter.py
@@ -1,0 +1,24 @@
+import torch
+
+
+class TransformedParameter(torch.nn.Module):
+    def __init__(self, value, transform):
+        """
+        Arguments
+        ---------
+        value : Tensor
+            The initial value of this learnable parameter
+        transform : torch.distributions.Transform
+            A transform instance which is applied to the underlying, unconstrained value
+        """
+        super().__init__()
+        value = torch.as_tensor(value)  # support floats
+        if isinstance(value, torch.nn.Parameter):
+            self._value = value
+            value.data = transform.inv(value)
+        else:
+            self._value = torch.nn.Parameter(transform.inv(value))
+        self.transform = transform
+
+    def forward(self):
+        return self.transform(self._value)

--- a/src/rs_distributions/modules/transformed_parameter.py
+++ b/src/rs_distributions/modules/transformed_parameter.py
@@ -2,14 +2,17 @@ import torch
 
 
 class TransformedParameter(torch.nn.Module):
+    """
+    A `torch.nn.Module` subclass representing a constrained variabled.
+    """
+
     def __init__(self, value, transform):
         """
-        Arguments
-        ---------
-        value : Tensor
-            The initial value of this learnable parameter
-        transform : torch.distributions.Transform
-            A transform instance which is applied to the underlying, unconstrained value
+        Args:
+            value : Tensor
+                The initial value of this learnable parameter
+            transform : torch.distributions.Transform
+                A transform instance which is applied to the underlying, unconstrained value
         """
         super().__init__()
         value = torch.as_tensor(value)  # support floats

--- a/tests/modules/test_distribution_modules.py
+++ b/tests/modules/test_distribution_modules.py
@@ -1,0 +1,75 @@
+import pytest
+from rs_distributions import modules as rsm
+import torch
+
+distribution_classes = rsm.DistributionModule._extract_distributions(
+        rsm, base_class=rsm.DistributionModule)
+
+# It is common to have arguments which are equivalent and mutually exclusive
+# in distribution classes.
+exlusive_args = [
+    ('logits', 'probs'),
+    ('covariance_matrix', 'precision_matrix', 'scale_tril'),
+]
+
+# Workarounds for distributions with additional, non-parameter arguments
+special_kwargs = {
+    "RelaxedBernoulli": {"temperature" : torch.ones(())},
+    "RelaxedOneHotCategorical": {"temperature" : torch.ones(())},
+    "TransformedDistribution" : {
+            "base_distribution" : rsm.Normal(0., 1.),
+            "transforms" : torch.distributions.AffineTransform(0., 1.),
+        },
+    "LKJCholesky": {"dim" : 3},
+    "Independent" : {
+            "base_distribution" : rsm.Normal(torch.zeros(3), torch.ones(3)),
+            "reinterpreted_batch_ndims" : 1,
+        },
+}
+
+@pytest.mark.parametrize('distribution_class_name', distribution_classes.keys())
+def test_distribution_module(distribution_class_name):
+    distribution_class = distribution_classes[distribution_class_name]
+    shape = (3,3)
+    kwargs = {}
+    cons = distribution_class.arg_constraints
+    for group in exlusive_args:
+        matches_group = all([g in cons for g in group])
+        if matches_group:
+            for con in group[1:]:
+                del(cons[con])
+    for k,v in cons.items():
+        try:
+            t = torch.distributions.constraint_registry.transform_to(v)
+            kwargs[k] = t(torch.ones(shape))
+        except NotImplementedError:
+            t = torch.distributions.AffineTransform(0., 1.)
+            kwargs[k] = rsm.TransformedParameter(v, t)
+
+
+    if distribution_class_name in special_kwargs:
+        kwargs.update(special_kwargs[distribution_class_name])
+    q = distribution_class(**kwargs)
+
+    # Not all distributions have these attributes implemented
+    try:
+        q.mean
+        q.variance
+        q.stddev
+    except NotImplementedError:
+        pass
+
+    if q.has_rsample:
+        z = q.rsample()
+    else:
+        z = q.sample()
+
+    ll = q.log_prob(z)
+
+    params = list(q.parameters())
+    if q.has_rsample:
+        loss = -ll.sum()
+        loss.backward()
+        for x in params:
+            assert torch.isfinite(x.grad).all()
+

--- a/tests/modules/test_distribution_modules.py
+++ b/tests/modules/test_distribution_modules.py
@@ -3,49 +3,50 @@ from rs_distributions import modules as rsm
 import torch
 
 distribution_classes = rsm.DistributionModule._extract_distributions(
-        rsm, base_class=rsm.DistributionModule)
+    rsm, base_class=rsm.DistributionModule
+)
 
 # It is common to have arguments which are equivalent and mutually exclusive
 # in distribution classes.
 exlusive_args = [
-    ('logits', 'probs'),
-    ('covariance_matrix', 'precision_matrix', 'scale_tril'),
+    ("logits", "probs"),
+    ("covariance_matrix", "precision_matrix", "scale_tril"),
 ]
 
 # Workarounds for distributions with additional, non-parameter arguments
 special_kwargs = {
-    "RelaxedBernoulli": {"temperature" : torch.ones(())},
-    "RelaxedOneHotCategorical": {"temperature" : torch.ones(())},
-    "TransformedDistribution" : {
-            "base_distribution" : rsm.Normal(0., 1.),
-            "transforms" : torch.distributions.AffineTransform(0., 1.),
-        },
-    "LKJCholesky": {"dim" : 3},
-    "Independent" : {
-            "base_distribution" : rsm.Normal(torch.zeros(3), torch.ones(3)),
-            "reinterpreted_batch_ndims" : 1,
-        },
+    "RelaxedBernoulli": {"temperature": torch.ones(())},
+    "RelaxedOneHotCategorical": {"temperature": torch.ones(())},
+    "TransformedDistribution": {
+        "base_distribution": rsm.Normal(0.0, 1.0),
+        "transforms": torch.distributions.AffineTransform(0.0, 1.0),
+    },
+    "LKJCholesky": {"dim": 3},
+    "Independent": {
+        "base_distribution": rsm.Normal(torch.zeros(3), torch.ones(3)),
+        "reinterpreted_batch_ndims": 1,
+    },
 }
 
-@pytest.mark.parametrize('distribution_class_name', distribution_classes.keys())
+
+@pytest.mark.parametrize("distribution_class_name", distribution_classes.keys())
 def test_distribution_module(distribution_class_name):
     distribution_class = distribution_classes[distribution_class_name]
-    shape = (3,3)
+    shape = (3, 3)
     kwargs = {}
     cons = distribution_class.arg_constraints
     for group in exlusive_args:
         matches_group = all([g in cons for g in group])
         if matches_group:
             for con in group[1:]:
-                del(cons[con])
-    for k,v in cons.items():
+                del cons[con]
+    for k, v in cons.items():
         try:
             t = torch.distributions.constraint_registry.transform_to(v)
             kwargs[k] = t(torch.ones(shape))
         except NotImplementedError:
-            t = torch.distributions.AffineTransform(0., 1.)
+            t = torch.distributions.AffineTransform(0.0, 1.0)
             kwargs[k] = rsm.TransformedParameter(v, t)
-
 
     if distribution_class_name in special_kwargs:
         kwargs.update(special_kwargs[distribution_class_name])
@@ -72,4 +73,3 @@ def test_distribution_module(distribution_class_name):
         loss.backward()
         for x in params:
             assert torch.isfinite(x.grad).all()
-

--- a/tests/modules/test_kl.py
+++ b/tests/modules/test_kl.py
@@ -1,0 +1,12 @@
+from rs_distributions import modules as rsm
+import torch
+
+
+def test_kl_divergence():
+    q = rsm.Normal(0., 1.)
+    p = torch.distributions.Normal(0., 1.)
+
+    assert all([param.grad is None for param in q.parameters()])
+    kl = rsm.kl_divergence(q, p)
+    kl.backward()
+    assert all([torch.isfinite(param.grad) for param in q.parameters()])

--- a/tests/modules/test_kl.py
+++ b/tests/modules/test_kl.py
@@ -3,8 +3,8 @@ import torch
 
 
 def test_kl_divergence():
-    q = rsm.Normal(0., 1.)
-    p = torch.distributions.Normal(0., 1.)
+    q = rsm.Normal(0.0, 1.0)
+    p = torch.distributions.Normal(0.0, 1.0)
 
     assert all([param.grad is None for param in q.parameters()])
     kl = rsm.kl_divergence(q, p)

--- a/tests/modules/test_transformed_parameter.py
+++ b/tests/modules/test_transformed_parameter.py
@@ -1,0 +1,25 @@
+import pytest
+from rs_distributions.modules import TransformedParameter
+import torch
+
+
+@pytest.mark.parametrize("shape", [(), 10])
+def test_transformed_parameter(shape):
+    value = 10.0
+    eps = 1e-6
+    transform = torch.distributions.ComposeTransform(
+        [
+            torch.distributions.AffineTransform(eps, 1.0),
+            torch.distributions.ExpTransform(),
+        ]
+    )
+    variable = TransformedParameter(value, transform)
+    assert variable() == value
+
+    params = list(variable.parameters())
+    assert len(params) == 1
+
+    loss = variable().square().sum()
+    loss.backward()
+    assert params[0].grad.isfinite().all()
+    assert (params[0] != 0).all()


### PR DESCRIPTION
Add `rs_distributions.modules` to contain learnable distributions with transformed parameter objects. The learnable distributions subclass `torch.nn.Module` and automatically biject apply transformations to their parameters in order to satisfy distribution constraints. Notably, these classes do not subclass torch.nn.Distribution, but they use delegation to access the attributes associated with distributions. 