### PR TITLE
Added new transforms submodules and fill_scale_tril.py transform to c…

### DIFF
--- a/src/rs_distributions/transforms/__init__.py
+++ b/src/rs_distributions/transforms/__init__.py
@@ -1,5 +1,7 @@
-from .fill_scale_tril import  FillScaleTriL
+from .fill_scale_tril import FillScaleTriL, FillTriL, DiagTransform
 
 __all__ = [
     "FillScaleTriL",
+    "FillTriL",
+    "DiagTransform",
 ]

--- a/src/rs_distributions/transforms/__init__.py
+++ b/src/rs_distributions/transforms/__init__.py
@@ -1,0 +1,5 @@
+from .fill_scale_tril import  FillScaleTriL
+
+__all__ = [
+    "FillScaleTriL",
+]

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -96,10 +96,12 @@ class FillScaleTriL(ComposeTransform):
 
     def __init__(self, diag_transform=None):
         if diag_transform is None:
-            diag_transform = torch.distributions.ComposeTransform((
+            diag_transform = torch.distributions.ComposeTransform(
+                (
                  SoftplusTransform(),
                  AffineTransform(1e-5, 1.),
-             ))
+             )
+            )
         super().__init__([FillTriL(), DiagTransform(diag_transform=diag_transform)])
         self.diag_transform = diag_transform
 

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -99,7 +99,7 @@ class FillScaleTriL(ComposeTransform):
             diag_transform = torch.distributions.ComposeTransform(
                 (
                  SoftplusTransform(),
-                 AffineTransform(1e-5, 1.),
+                 AffineTransform(1e-5, 1.0),
              )
             )
         super().__init__([FillTriL(), DiagTransform(diag_transform=diag_transform)])

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -5,7 +5,7 @@ from torch.distributions.utils import vec_to_tril_matrix, tril_matrix_to_vec
 
 
 class FillScaleTriL(Transform):
-    def __init__(self, diag_transform=None, diag_shift=1e-05):
+    def __init__(self, diag_transform=None, diag_shift=1e-06):
         """
         Converts a tensor into a lower triangular matrix with positive diagonal entries.
 
@@ -13,7 +13,7 @@ class FillScaleTriL(Transform):
             diag_transform: transformation used on diagonal to ensure positive values.
             Default is SoftplusTransform
             diag_shift (float): small offset to avoid diagonals very close to zero.
-            Default offset is 1e-05
+            Default offset is 1e-06
 
         """
         super().__init__()
@@ -22,9 +22,17 @@ class FillScaleTriL(Transform):
         )
         self.diag_shift = diag_shift
 
-        domain = constraints.real_vector
-        codomain = constraints.lower_cholesky
-        bijective = True
+    @property
+    def domain(self):
+        return constraints.real_vector
+
+    @property
+    def codomain(self):
+        return constraints.lower_cholesky
+
+    @property
+    def bijective(self):
+        return True
 
     def _call(self, x):
         """
@@ -36,12 +44,14 @@ class FillScaleTriL(Transform):
             torch.Tensor: Transformed lower triangular matrix
         """
         x = vec_to_tril_matrix(x)
-        diagonal_elements = x.diagonal(dim1=-2, dim2=-1)
-        transformed_diagonal = self.diag_transform(diagonal_elements)
+        diagonal = x.diagonal(dim1=-2, dim2=-1)
         if self.diag_shift is not None:
-            transformed_diagonal += self.diag_shift
-        x.diagonal(dim1=-2, dim2=-1).copy_(transformed_diagonal)
-        return x
+            result = x.diagonal_scatter(
+                self.diag_transform(diagonal + self.diag_shift), dim1=-2, dim2=-1
+            )
+        else:
+            result = x.diagonal_scatter(self.diag_transform(diagonal), dim1=-2, dim2=-1)
+        return result
 
     def _inverse(self, y):
         """
@@ -54,31 +64,29 @@ class FillScaleTriL(Transform):
             torch.Tensor: Inversely transformed vector
 
         """
-        diagonal_elements = y.diagonal(dim1=-2, dim2=-1)
+        diagonal = y.diagonal(dim1=-2, dim2=-1)
         if self.diag_shift is not None:
-            transformed_diagonal = self.diag_transform.inv(
-                diagonal_elements - self.diag_shift
+            result = y.diagonal_scatter(
+                self.diag_transform.inv(diagonal - self.diag_shift), dim1=-2, dim2=-1
             )
         else:
-            transformed_diagonal = self.diag_transform.inv(diagonal_elements)
-        y.diagonal(dim1=-2, dim2=-1).copy_(transformed_diagonal)
-        return tril_matrix_to_vec(y)
+            result = y.diagonal_scatter(
+                self.diag_transform.inv(diagonal), dim1=-2, dim2=-1
+            )
+        return tril_matrix_to_vec(result)
 
     def log_abs_det_jacobian(self, x, y):
-        """
-        Computes the log absolute determinant of the Jacobian matrix for the transformation.
-
-        Assumes that Softplus is used on the diagonal.
-        The derivative of the softplus function is the sigmoid function.
-
-        Args:
-            x (torch.Tensor): Input vector before transformation
-            y (torch.Tensor): Output lower triangular matrix from _call
-
-        Returns:
-            torch.Tensor: Log absolute determinant of the Jacobian matrix
-        """
-        diag_elements = y.diagonal(dim1=-2, dim2=-1)
-        derivatives = torch.sigmoid(diag_elements)
-        log_det_jacobian = torch.log(derivatives).sum()
+        L = vec_to_tril_matrix(x)
+        diag = L.diagonal(dim1=-2, dim2=-1)
+        diag.requires_grad_(True)
+        if self.diag_shift is not None:
+            transformed_diag = self.diag_transform(diag + self.diag_shift)
+        else:
+            transformed_diag = self.diag_transform(diag)
+        derivatives = torch.autograd.grad(
+            outputs=transformed_diag,
+            inputs=diag,
+            grad_outputs=torch.ones_like(transformed_diag),
+        )[0]
+        log_det_jacobian = torch.log(torch.abs(derivatives)).sum()
         return log_det_jacobian

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -115,7 +115,7 @@ class FillScaleTriL(ComposeTransform):
     @staticmethod
     def params_size(event_size):
         """
-        Returns the number of parameters required to create lower triangular matrix, which is given by n*(n+1)//2
+        Returns the number of parameters required to create an n-by-n lower triangular matrix, which is given by n*(n+1)//2
 
         Args: 
             event_size (int): size of event

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -1,0 +1,84 @@
+import torch
+from torch.distributions import Transform, constraints
+from torch.distributions.transforms import SoftplusTransform
+from torch.distributions.utils import vec_to_tril_matrix, tril_matrix_to_vec
+
+
+class FillScaleTriL(Transform):
+    def __init__(self, diag_transform=None, diag_shift=1e-05):
+        """
+        Converts a tensor into a lower triangular matrix with positive diagonal entries.
+
+        Args:
+            diag_transform: transformation used on diagonal to ensure positive values.
+            Default is SoftplusTransform
+            diag_shift (float): small offset to avoid diagonals very close to zero.
+            Default offset is 1e-05
+
+        """
+        super().__init__()
+        self.diag_transform = (
+            diag_transform if diag_transform is not None else SoftplusTransform()
+        )
+        self.diag_shift = diag_shift
+
+        domain = constraints.real_vector
+        codomain = constraints.lower_cholesky
+        bijective = True
+
+    def _call(self, x):
+        """
+        Transform input vector to lower triangular.
+
+        Args:
+            x (torch.Tensor): Input vector to transform
+        Returns:
+            torch.Tensor: Transformed lower triangular matrix
+        """
+        x = vec_to_tril_matrix(x)
+        diagonal_elements = x.diagonal(dim1=-2, dim2=-1)
+        transformed_diagonal = self.diag_transform(diagonal_elements)
+        if self.diag_shift is not None:
+            transformed_diagonal += self.diag_shift
+        x.diagonal(dim1=-2, dim2=-1).copy_(transformed_diagonal)
+        return x
+
+    def _inverse(self, y):
+        """
+        Apply the inverse transformation to the input lower triangular matrix.
+
+        Args:
+            y (torch.Tensor): Invertible lower triangular matrix
+
+        Returns:
+            torch.Tensor: Inversely transformed vector
+
+        """
+        diagonal_elements = y.diagonal(dim1=-2, dim2=-1)
+        if self.diag_shift is not None:
+            transformed_diagonal = self.diag_transform.inv(
+                diagonal_elements - self.diag_shift
+            )
+        else:
+            transformed_diagonal = self.diag_transform.inv(diagonal_elements)
+        y.diagonal(dim1=-2, dim2=-1).copy_(transformed_diagonal)
+        return tril_matrix_to_vec(y)
+
+    def log_abs_det_jacobian(self, x, y):
+        """
+        Computes the log absolute determinant of the Jacobian matrix for the transformation.
+
+        Assumes that Softplus is used on the diagonal.
+        The derivative of the softplus function is the sigmoid function.
+
+        Args:
+            x (torch.Tensor): Input vector before transformation
+            y (torch.Tensor): Output lower triangular matrix from _call
+
+        Returns:
+            torch.Tensor: Log absolute determinant of the Jacobian matrix
+        """
+        diag_elements = y.diagonal(dim1=-2, dim2=-1)
+        derivatives = torch.sigmoid(diag_elements)
+        log_det_jacobian = torch.log(derivatives).sum()
+        return log_det_jacobian

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -100,7 +100,7 @@ class FillScaleTriL(ComposeTransform):
                 (
                  SoftplusTransform(),
                  AffineTransform(1e-5, 1.0),
-             )
+                )
             )
         super().__init__([FillTriL(), DiagTransform(diag_transform=diag_transform)])
         self.diag_transform = diag_transform
@@ -121,7 +121,6 @@ class FillScaleTriL(ComposeTransform):
 
         Args: 
             event_size (int): size of event
-
         Returns:
             int: Number of parameters needed
 

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -95,11 +95,12 @@ class FillScaleTriL(ComposeTransform):
     """
 
     def __init__(self, diag_transform=None):
+        
         if diag_transform is None:
             diag_transform = torch.distributions.ComposeTransform(
                 (
-                 SoftplusTransform(),
-                 AffineTransform(1e-5, 1.0),
+                    SoftplusTransform(),
+                    AffineTransform(1e-5, 1.0),
                 )
             )
         super().__init__([FillTriL(), DiagTransform(diag_transform=diag_transform)])

--- a/src/rs_distributions/transforms/fill_scale_tril.py
+++ b/src/rs_distributions/transforms/fill_scale_tril.py
@@ -95,7 +95,6 @@ class FillScaleTriL(ComposeTransform):
     """
 
     def __init__(self, diag_transform=None):
-        
         if diag_transform is None:
             diag_transform = torch.distributions.ComposeTransform(
                 (
@@ -120,7 +119,7 @@ class FillScaleTriL(ComposeTransform):
         """
         Returns the number of parameters required to create an n-by-n lower triangular matrix, which is given by n*(n+1)//2
 
-        Args: 
+        Args:
             event_size (int): size of event
         Returns:
             int: Number of parameters needed

--- a/tests/transforms/fill_scale_tril.py
+++ b/tests/transforms/fill_scale_tril.py
@@ -1,0 +1,27 @@
+import pytest
+from rs_distributions.transforms.fill_scale_tril import FillScaleTriL
+import torch
+from torch.distributions.constraints import lower_cholesky
+
+
+@pytest.mark.parametrize("input_shape", [(6,), (10,)])
+def test_forward_transform(input_shape):
+    transform = FillScaleTriL()
+    input_vector = torch.randn(input_shape)
+    transformed_vector = transform._call(input_vector)
+
+    assert isinstance(transformed_vector, torch.Tensor)
+    assert transformed_vector.shape == (
+        (-1 + torch.sqrt(torch.tensor(1 + input_shape[0] * 8))) / 2,
+        (-1 + torch.sqrt(torch.tensor(1 + input_shape[0] * 8))) / 2,
+    )
+    assert lower_cholesky.check(transformed_vector)
+
+
+@pytest.mark.parametrize("input_vector", [torch.randn(3), torch.randn(6)])
+def test_forward_equals_inverse(input_vector):
+    transform = FillScaleTriL()
+    L = transform._call(input_vector)
+    invL = transform._inverse(L)
+
+    assert torch.allclose(input_vector, invL, atol=1e-6)

--- a/tests/transforms/fill_scale_tril.py
+++ b/tests/transforms/fill_scale_tril.py
@@ -51,22 +51,22 @@ def test_forward_equals_inverse(batch_shape, d):
 )
 def test_log_abs_det_jacobian_softplus_and_exp(batch_shape, d, diag_transform):
     transform = FillScaleTriL(diag_transform=diag_transform)
+    filltril = FillTriL()
+    diagtransform = DiagTransform(diag_transform=diag_transform)
     input_shape = batch_shape + (d,)
     input_vector = torch.randn(input_shape, requires_grad=True)
     transformed_vector = transform(input_vector)
 
-    # Calculate log abs det jacobian with autograd
+    # Calculate gradients log_abs_det_jacobian from FillScaleTriL
     log_abs_det_jacobian = transform.log_abs_det_jacobian(
         input_vector, transformed_vector
     )
 
     # Extract diagonal elements from input and transformed vectors
-    filltril = FillTriL()
-    diagtransform = DiagTransform(diag_transform=diag_transform)
     tril = filltril(input_vector)
     diagonal_transformed = diagtransform(tril)
 
-    # Calculate diagonal gradients with autograd
+    # Calculate diagonal gradients
     diag_jacobian = diagtransform.log_abs_det_jacobian(tril, diagonal_transformed)
 
     # Assert diagonal gradients are approximately equal

--- a/tests/transforms/fill_scale_tril.py
+++ b/tests/transforms/fill_scale_tril.py
@@ -1,13 +1,7 @@
 import pytest
 from rs_distributions.transforms.fill_scale_tril import FillScaleTriL
 import torch
-from torch.distributions.utils import vec_to_tril_matrix, tril_matrix_to_vec
 from torch.distributions.constraints import lower_cholesky
-from torch.distributions.transforms import (
-    ComposeTransform,
-    ExpTransform,
-    SoftplusTransform,
-)
 
 
 @pytest.mark.parametrize("batch_shape, d", [((2, 3), 6), ((1, 4, 5), 10)])

--- a/tests/transforms/fill_scale_tril.py
+++ b/tests/transforms/fill_scale_tril.py
@@ -1,5 +1,7 @@
 import pytest
-from rs_distributions.transforms.fill_scale_tril import FillScaleTriL
+from rs_distributions.transforms.fill_scale_tril import (
+    FillScaleTriL,
+)
 import torch
 from torch.distributions.constraints import lower_cholesky
 
@@ -9,7 +11,7 @@ def test_forward_transform(batch_shape, d):
     transform = FillScaleTriL()
     input_shape = batch_shape + (d,)
     input_vector = torch.randn(input_shape)
-    transformed_vector = transform._call(input_vector)
+    transformed_vector = transform(input_vector)
 
     n = int((-1 + torch.sqrt(torch.tensor(1 + 8 * d))) / 2)
     expected_output_shape = batch_shape + (n, n)
@@ -27,10 +29,8 @@ def test_forward_equals_inverse(batch_shape, d):
     transform = FillScaleTriL()
     input_shape = batch_shape + (d,)
     input_vector = torch.randn(input_shape)
-    L = transform._call(input_vector)
-    invL = transform._inverse(L)
-
-    n = int((-1 + torch.sqrt(torch.tensor(1 + 8 * d))) / 2)
+    L = transform(input_vector)
+    invL = transform.inv(L)
 
     assert torch.allclose(
         input_vector, invL, atol=1e-4


### PR DESCRIPTION
This PR adds a `transforms` submodule directory as well as a 'fill_scale_tril.py' transform to convert vectors into a lower triangular matrix with a positive diagonal. The current implementation uses a `SoftplusTransform' to constraint the diagonal. This should be compatible with [torch.distributions.transforms.ComposeTransform](https://pytorch.org/docs/stable/distributions.html#torch.distributions.transforms.ComposeTransform), but I have not tested it. 