### PR TITLE
explicitly specify torch dtype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "torch>=2.5",
+    "torch",
     "numpy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "torch>2.2",
+    "torch>=2.5",
     "numpy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "torch",
+    "torch>2.2",
     "numpy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ cov-report = [
   "coverage report",
 ]
 cov = [
+  "pip list",
   "test-cov",
   "cov-report",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "torch",
-    "numpy",
+    "numpy<2",
 ]
 
 [project.urls]

--- a/tests/distributions/test_rice.py
+++ b/tests/distributions/test_rice.py
@@ -45,8 +45,8 @@ def test_rice_against_scipy(
     nu, sigma = nu[idx], sigma[idx]
 
     q = Rice(
-        torch.as_tensor(nu),
-        torch.as_tensor(sigma),
+        torch.as_tensor(nu, dtype=torch.float32),
+        torch.as_tensor(sigma, dtype=torch.float32),
     )
 
     mean = rice.mean(nu / sigma, scale=sigma).astype(dtype)


### PR DESCRIPTION
hopefully this fixes the issue with the tests on python 3.9