### PR TITLE
specify numpy<2 for python<3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, numpy1py39]
   pull_request:
     branches: [main]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cov-report = [
   "coverage report",
 ]
 cov = [
-  "pip list"
+  "pip list",
   "test-cov",
   "cov-report",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ cov-report = [
   "coverage report",
 ]
 cov = [
+  "pip list"
   "test-cov",
   "cov-report",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 dependencies = [
     "torch",
-    "numpy",
+    "numpy>=2.1.1; python_version>='3.10'",
+    "numpy<2.0.0; python_version<'3.10'",
 ]
 
 [project.urls]


### PR DESCRIPTION
The Python 3.9 build is failing on MacOS with numpy>=2