### PR TITLE
Added loc/scale threshold to FoldedNormal

### DIFF
--- a/src/rs_distributions/distributions/folded_normal.py
+++ b/src/rs_distributions/distributions/folded_normal.py
@@ -119,7 +119,7 @@ class FoldedNormal(dist.Distribution):
                 loc[small] + mean[small]
             )
 
-        return loc**2 + scale**2 - self.mean**2
+        return var
 
     def cdf(self, value):
         """

--- a/src/rs_distributions/distributions/folded_normal.py
+++ b/src/rs_distributions/distributions/folded_normal.py
@@ -115,9 +115,7 @@ class FoldedNormal(dist.Distribution):
             var[large] = scale[large] ** 2
 
         if small.any():
-            var[small] = scale[small] ** 2 + (loc[small] - mean[small]) * (
-                loc[small] + mean[small]
-            )
+            var[small] = loc[small] ** 2 + scale[small] ** 2 - mean[small] ** 2
 
         return var
 


### PR DESCRIPTION
Added a lower bound threshold `var_thresh` to switch between using the FoldedNormal variance, or the underlying Normal variance.

Will use the `Normal` variance when the ratio `loc/scale` is greater than `var_thresh`.