### PR TITLE
Dropped support for python < 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,65 +1,46 @@
 name: Build
-
 on:
   push:
     branches: [main, numpy1py39]
   pull_request:
     branches: [main]
-
 concurrency:
   group: test-${{ github.head_ref }}
   cancel-in-progress: true
-
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
-
 jobs:
   run:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
     runs-on: ${{ matrix.os }}
-
     # skip build of commit contains 'skip ci'
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-
     strategy:
       fail-fast: false
       matrix:
         python-version:
-        - "3.8"
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.x"
         os:
-        - "windows-latest"
-        - "macos-latest"
-        - "ubuntu-latest"
-        # Based on peps #3763 (https://github.com/python/peps/pull/3763) via 
-        # setup-python #850 (https://github.com/actions/setup-python/issues/850)
-        exclude:
-        - { python-version: "3.8", os: "macos-latest" }
-        - { python-version: "3.9", os: "macos-latest" }
-        include:
-        - { python-version: "3.8", os: "macos-13" }
-        - { python-version: "3.9", os: "macos-13" }
-
+          - "windows-latest"
+          - "macos-latest"
+          - "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install Hatch
-      run: |
-        pip install --upgrade pip
-        pip install --upgrade hatch
-        pip install hatch-mkdocs #This is a workaround  for https://github.com/pypa/hatch/issues/1379
-
-    - name: Run static analysis
-      run: hatch fmt --check
-
-    - name: Run tests
-      run: hatch run cov
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Hatch
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade hatch
+          pip install hatch-mkdocs #This is a workaround  for https://github.com/pypa/hatch/issues/1379
+      - name: Run static analysis
+        run: hatch fmt --check
+      - name: Run tests
+        run: hatch run cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.x"
         os:
           - "windows-latest"
           - "macos-latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rs-distributions"
 dynamic = ["version"]
 description = 'Statistical distributions for structural biology'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -17,12 +17,10 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -60,7 +58,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.types]
 dependencies = [


### PR DESCRIPTION
Updated the gh build matrix to drop support for python < 3.10, and include support up to python 3.13. Also updated the `pyproject.toml` to reflect these changes. 
